### PR TITLE
Check the output from shell_exec() before calling trim()

### DIFF
--- a/src/TrailCamSorter/Classes/TrailCamSorter.php
+++ b/src/TrailCamSorter/Classes/TrailCamSorter.php
@@ -994,7 +994,10 @@ class TrailCamSorter
         );
 
         // Execute Tesseract and capture the output.
-        $output = trim(shell_exec($tesseractCommand));
+        $output = shell_exec($tesseractCommand);
+        if (!empty($output)) {
+            $output = trim($output);
+        }
 
         // Delete the temporary image file.
         unlink($tempImageFile);


### PR DESCRIPTION
- Fixes a PHP Deprecated error when shell_exec() returns null.